### PR TITLE
add custom code emotion component

### DIFF
--- a/Views/widgets/emotion/components/emotion_custom.tpl
+++ b/Views/widgets/emotion/components/emotion_custom.tpl
@@ -1,0 +1,3 @@
+{block name="widgets_emotion_components_toolkit_custom"}
+  {$Data.html_code}
+{/block}


### PR DESCRIPTION
for users of any pre-5.2 Shopware version, it's very hard to add custom JavaScript to a shop page via Emotion (Shopping Worlds). This PR adds an emotion component for shops running Shopware < 5.2 that lets the shop administrator add custom HTML/Javascript without filtering.