### PR TITLE
Reimplement custom HTML/JS emotion component

### DIFF
--- a/CompilerPasses/EmotionComponentPass.php
+++ b/CompilerPasses/EmotionComponentPass.php
@@ -1,8 +1,10 @@
 <?php
-/**
- * @copyright  Copyright (c) 2017, Net Inventors GmbH
+
+/*
+ * @copyright  Copyright (c) 2016, Net Inventors GmbH
  * @category   Shopware
- * @author     hrombach
+ * @author     Net Inventors GmbH
+ *
  */
 
 namespace NetiToolKit\CompilerPasses;

--- a/CompilerPasses/EmotionComponentPass.php
+++ b/CompilerPasses/EmotionComponentPass.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright  Copyright (c) 2017, Net Inventors GmbH
+ * @category   Shopware
+ * @author     hrombach
+ */
+
+namespace NetiToolKit\CompilerPasses;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class EmotionComponentPass implements CompilerPassInterface
+{
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('shopware.emotion_component_installer')) {
+            $container->removeDefinition('neti_tool_kit.emotion_view_subscriber');
+        }
+    }
+}

--- a/NetiToolKit.php
+++ b/NetiToolKit.php
@@ -69,5 +69,4 @@ class NetiToolKit extends Plugin
 
         parent::build($container);
     }
-
 }

--- a/NetiToolKit.php
+++ b/NetiToolKit.php
@@ -34,6 +34,17 @@ class NetiToolKit extends Plugin
     }
 
     /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        // avoid DI errors in Shopware < 5.2.10
+        $container->addCompilerPass(new EmotionComponentPass());
+
+        parent::build($container);
+    }
+
+    /**
      * @param ComponentInstaller $emotionInstaller
      */
     private function createEmotionComponent(ComponentInstaller $emotionInstaller)
@@ -57,16 +68,5 @@ class NetiToolKit extends Plugin
                 'allowBlank'  => false,
             ]
         );
-    }
-
-    /**
-     * @param ContainerBuilder $container
-     */
-    public function build(ContainerBuilder $container)
-    {
-        // avoid DI errors in Shopware < 5.2.10
-        $container->addCompilerPass(new EmotionComponentPass());
-
-        parent::build($container);
     }
 }

--- a/NetiToolKit.php
+++ b/NetiToolKit.php
@@ -9,8 +9,65 @@
 
 namespace NetiToolKit;
 
+use NetiToolKit\CompilerPasses\EmotionComponentPass;
+use Shopware\Components\DependencyInjection\Container;
+use Shopware\Components\Emotion\ComponentInstaller;
 use Shopware\Components\Plugin;
+use Shopware\Components\Plugin\Context\InstallContext;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class NetiToolKit extends Plugin
 {
+    /**
+     * @param InstallContext $context
+     */
+    public function install(InstallContext $context)
+    {
+        $emotionInstaller = $this->container->get(
+            'shopware.emotion_component_installer',
+            Container::NULL_ON_INVALID_REFERENCE
+        );
+
+        if ($emotionInstaller instanceof ComponentInstaller) {
+            $this->createEmotionComponent($emotionInstaller);
+        }
+    }
+
+    /**
+     * @param ComponentInstaller $emotionInstaller
+     */
+    private function createEmotionComponent(ComponentInstaller $emotionInstaller)
+    {
+        $customCodeElement = $emotionInstaller->createOrUpdate(
+            $this->getName(),
+            'Custom HTML/JS',
+            [
+                'name'        => 'ToolKit Custom Code',
+                'template'    => 'neti_tool_kit_emotion_custom',
+                'cls'         => 'emotion-tool_kit-element',
+                'description' => 'Custom HTML/JS Code that will be output as-is in the emotion element.',
+            ]
+        );
+
+        $customCodeElement->createTextAreaField(
+            [
+                'name'        => 'html_code',
+                'fieldLabel'  => 'Code:',
+                'supportText' => 'Enter HTML/JS Code here, it will be not be altered in any way.',
+                'allowBlank'  => false,
+            ]
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        // avoid DI errors in Shopware < 5.2.10
+        $container->addCompilerPass(new EmotionComponentPass());
+
+        parent::build($container);
+    }
+
 }

--- a/NetiToolKit.php
+++ b/NetiToolKit.php
@@ -10,11 +10,11 @@
 namespace NetiToolKit;
 
 use NetiToolKit\CompilerPasses\EmotionComponentPass;
-use Shopware\Components\DependencyInjection\Container;
 use Shopware\Components\Emotion\ComponentInstaller;
 use Shopware\Components\Plugin;
 use Shopware\Components\Plugin\Context\InstallContext;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class NetiToolKit extends Plugin
 {
@@ -25,7 +25,7 @@ class NetiToolKit extends Plugin
     {
         $emotionInstaller = $this->container->get(
             'shopware.emotion_component_installer',
-            Container::NULL_ON_INVALID_REFERENCE
+            ContainerInterface::NULL_ON_INVALID_REFERENCE
         );
 
         if ($emotionInstaller instanceof ComponentInstaller) {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin for Shopware  provides some usefull functions and tools wich every d
 ## Install:
 1. If you haven't already, download and install our free plugin "[NetiFoundation](http://store.shopware.com/detail/index/sArticle/162025)" from the Shopware Community Store
 2. Download this plugin via [Shopware Store](http://store.shopware.com/detail/index/sArticle/163077) or clone this repository to the
-*"engine/Shopware/Plugins/Core"* folder, **remember to name the plugin folder "NetiToolKit"** and install through the Plugin Manager
+*"engine/Shopware/custom/plugins/"* folder, **remember to name the plugin folder "NetiToolKit"** and install through the Plugin Manager
 
 ## Configuration:
 > Because some of these Features were moved from the Net Inventors Foundation Plugin the features **UserData**
@@ -34,6 +34,12 @@ If the user is logged in you can access the user infos on every page
 ### UserLoggedIn
 Here you can check globally if the user is logged in
 * Accessed in Smarty via `{$sUserLoggedIn}`
+
+### Custom HTML / JS Code Emotion component (SW >= 5.2.10)
+An emotion (Shopping worlds) component that enables you to add arbitrary HTML / JS code to shop pages with no 
+filtering or alteration. This differs from the default custom code emotion component in that you can mix JS and HTML code.
+As this code is relayed to the page with no alteration, we take no responsibility for any problems resulting from this. 
+Use at your own risk!
 
 ## VCS
 https://github.com/NetInventors/sw.ext.neti_tool_kit/

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -20,5 +20,12 @@
             <argument type="service" id="neti_foundation.plugin_manager_config"/>
             <tag name="shopware.event_subscriber"/>
         </service>
+
+        <!-- Emotion event subscriber -->
+        <service id="neti_tool_kit.emotion_view_subscriber"
+                 class="Shopware\Components\Emotion\EmotionComponentViewSubscriber">
+            <argument>%neti_tool_kit.plugin_dir%</argument>
+            <tag name="shopware.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/Resources/views/emotion_components/widgets/emotion/components/neti_tool_kit_emotion_custom.tpl
+++ b/Resources/views/emotion_components/widgets/emotion/components/neti_tool_kit_emotion_custom.tpl
@@ -1,0 +1,3 @@
+{block name="widgets_emotion_components_toolkit_custom"}
+    {$Data.html_code}
+{/block}

--- a/Subscriber/GlobalData.php
+++ b/Subscriber/GlobalData.php
@@ -76,11 +76,16 @@ class GlobalData implements SubscriberInterface
         $view = $args->getSubject()->View();
 
         if (null === $this->userLoggedIn) {
-            $this->userLoggedIn = (bool)$this->session->sUserId;
+            $this->userLoggedIn = (bool)$this->session->get('sUserId');
         }
 
         $netiUserData = [];
 
+    /**
+     * @param $view
+     */
+    private function handleGlobalUserData(\Enlight_View_Default $view)
+    {
         // assign userData array to smarty
         if ($this->pluginConfig->isGlobalUserData() && $this->userLoggedIn) {
             $this->addUserData($netiUserData);

--- a/Subscriber/GlobalData.php
+++ b/Subscriber/GlobalData.php
@@ -81,11 +81,6 @@ class GlobalData implements SubscriberInterface
 
         $netiUserData = [];
 
-    /**
-     * @param $view
-     */
-    private function handleGlobalUserData(\Enlight_View_Default $view)
-    {
         // assign userData array to smarty
         if ($this->pluginConfig->isGlobalUserData() && $this->userLoggedIn) {
             $this->addUserData($netiUserData);

--- a/Subscriber/ListingProperties.php
+++ b/Subscriber/ListingProperties.php
@@ -84,26 +84,12 @@ class ListingProperties implements SubscriberInterface
             return;
         }
 
-        $return = $args->getReturn();
-
-        //turn sArticles array into BaseProduct Structs
-        $products = [];
-        foreach ($return['sArticles'] as $sArticle) {
-            $products[$sArticle['ordernumber']] = new BaseProduct(
-                $sArticle['articleID'],
-                $sArticle['articleDetailsID'],
-                $sArticle['ordernumber']
-            );
-        }
+        $return   = $args->getReturn();
+        $products = $this->getProductStructsFromViewArticles($return['sArticles']);
 
         // get property set Structs
         $propertySets = $this->propertyService->getList($products, $this->contextService->getShopContext());
-
-        // convert property set Structs to legacy Array format
-        $legacyProps = [];
-        foreach ($propertySets as $ordernumber => $propertySet) {
-            $legacyProps[$ordernumber] = $this->structConverter->convertPropertySetStruct($propertySet);
-        }
+        $legacyProps  = $this->convertPropertyStructs($propertySets);
 
         // add property arrays to sArticles array
         foreach ($return['sArticles'] as &$sArticle) {
@@ -112,5 +98,41 @@ class ListingProperties implements SubscriberInterface
         unset($sArticle);
 
         $args->setReturn($return);
+    }
+
+    /**
+     * @param array $sArticles
+     *
+     * @return BaseProduct[]
+     */
+    private function getProductStructsFromViewArticles(array $sArticles)
+    {
+        //turn sArticles array into BaseProduct Structs
+        $products = [];
+        foreach ($sArticles as $sArticle) {
+            $products[$sArticle['ordernumber']] = new BaseProduct(
+                $sArticle['articleID'],
+                $sArticle['articleDetailsID'],
+                $sArticle['ordernumber']
+            );
+        }
+
+        return $products;
+    }
+
+    /**
+     * @param $propertySets
+     *
+     * @return array
+     */
+    private function convertPropertyStructs($propertySets)
+    {
+        // convert property set Structs to legacy Array format
+        $legacyProps = [];
+        foreach ($propertySets as $ordernumber => $propertySet) {
+            $legacyProps[$ordernumber] = $this->structConverter->convertPropertySetStruct($propertySet);
+        }
+
+        return $legacyProps;
     }
 }

--- a/Subscriber/ListingProperties.php
+++ b/Subscriber/ListingProperties.php
@@ -97,7 +97,7 @@ class ListingProperties implements SubscriberInterface
         }
 
         // get property set Structs
-        $propertySets = $this->propertyService->getList($products, $this->contextService->getContext());
+        $propertySets = $this->propertyService->getList($products, $this->contextService->getShopContext());
 
         // convert property set Structs to legacy Array format
         $legacyProps = [];

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "netinventors/sw.ext.neti_tool_kit",
+    "type": "project",
+    "require": {
+        "shopware/shopware": "^5.2.6"
+    },
+    "license": "MIT",
+    "minimum-stability": "stable"
+}

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "netinventors/sw.ext.neti_tool_kit",
-    "type": "project",
-    "require": {
-        "shopware/shopware": "^5.2.6"
-    },
-    "license": "MIT",
-    "minimum-stability": "stable"
+  "name": "netinventors/sw.ext.neti_tool_kit",
+  "type": "project",
+  "require": {
+    "shopware/shopware": "^5.2.6"
+  },
+  "license": "MIT",
+  "minimum-stability": "stable"
 }

--- a/config.php
+++ b/config.php
@@ -11,7 +11,6 @@ return [
     'redmine' => [
         'projectID' => '000000-012-447',
         'contact'   => 'hr@netinventors.de',
-
     ],
     'form'    => [
         [

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,10 +14,12 @@
         <changes lang="de"><![CDATA[
 [#26336] Attribut-Daten und Firmenname zum UserData-Array hinzugefügt.
 Die Konfigurationsoption für die sUserLoggedIn-Smarty-Variable wurde aus Performance-Gründen entfernt, der Wert wird nun immer ans Template übergeben.
+[#25802] Custom HTML/JS Code Einkaufsweltelement wurde reimplementiert.
 ]]></changes>
         <changes lang="en"><![CDATA[
 [#26336] Added attribute data and company name to user data array.
 The config option to disable the sUserLoggedIn smarty variable was removed for performance reasons. The variable is now always assigned.
+[#25802] Reimplement custom HTML/JS Code emotion component.
 ]]></changes>
     </changelog>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,13 +13,13 @@
     <changelog version="2.1.0">
         <changes lang="de"><![CDATA[
 [#26336] Attribut-Daten und Firmenname zum UserData-Array hinzugefügt.
-Die Konfigurationsoption für die sUserLoggedIn-Smarty-Variable wurde aus Performance-Gründen entfernt, der Wert wird nun immer ans Template übergeben.
 [#25802] Custom HTML/JS Code Einkaufsweltelement wurde reimplementiert.
+Die Konfigurationsoption für die sUserLoggedIn-Smarty-Variable wurde aus Performance-Gründen entfernt, der Wert wird nun immer ans Template übergeben.
 ]]></changes>
         <changes lang="en"><![CDATA[
 [#26336] Added attribute data and company name to user data array.
-The config option to disable the sUserLoggedIn smarty variable was removed for performance reasons. The variable is now always assigned.
 [#25802] Reimplement custom HTML/JS Code emotion component.
+The config option to disable the sUserLoggedIn smarty variable was removed for performance reasons. The variable is now always assigned.
 ]]></changes>
     </changelog>
 


### PR DESCRIPTION
Brings back the custom HTML / JS emotion component as requested in #11 

Due to changes in the way emotion components are registered, this feature will only show up in Shopware 5.2.10 and above, but it will not break compatibility.