### PR TITLE
#26409 - Fix Fatal error in frontend and add support for emotionArticleSlider

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -28,7 +28,7 @@ enabled:
   - no_useless_return # There should not be an empty return statement at the end of a function
   - no_whitespace_in_blank_line # Remove trailing whitespace at the end of blank lines
   - object_operator_without_whitespace # There should not be space before or after object T_OBJECT_OPERATOR
-  - ordered_class_elements # Orders the elements of classes/interfaces/traits
+  #- ordered_class_elements # Orders the elements of classes/interfaces/traits
   - phpdoc_add_missing_param_annotation # phpdoc_add_missing_param_annotation
   - phpdoc_align # All items of the @param, @throws, @return, @var, and @type phpdoc tags must be aligned vertically
   - phpdoc_indent # Docblocks should have the same indentation as the documented subject

--- a/Struct/PluginConfig.php
+++ b/Struct/PluginConfig.php
@@ -13,10 +13,11 @@ use NetiFoundation\Struct\AbstractClass;
 
 class PluginConfig extends AbstractClass
 {
-    const SHOW_PROPERTIES_ON_SIMILAR_ARTICLES = 'similarArticles';
-    const SHOW_PROPERTIES_ON_TOP_SELLER       = 'topSeller';
-    const SHOW_PROPERTIES_ON_LISTING          = 'listing';
-    const SHOW_PROPERTIES_ON_BOUGHT           = 'bought';
+    const SHOW_PROPERTIES_ON_EMOTION_ARTICLE_SLIDER = 'emotionArticleSlider';
+    const SHOW_PROPERTIES_ON_SIMILAR_ARTICLES       = 'similarArticles';
+    const SHOW_PROPERTIES_ON_TOP_SELLER             = 'topSeller';
+    const SHOW_PROPERTIES_ON_LISTING                = 'listing';
+    const SHOW_PROPERTIES_ON_BOUGHT                 = 'bought';
 
     /**
      * @var bool - provide $netiUserData globally

--- a/Subscriber/FrontendProperties.php
+++ b/Subscriber/FrontendProperties.php
@@ -67,54 +67,29 @@ class FrontendProperties implements SubscriberInterface
         return [
             'Enlight_Controller_Action_PostDispatchSecure_Widgets_Recommendation' => 'addPropsToBought',
             'Enlight_Controller_Action_PostDispatchSecure_Widgets_Listing'        => 'addPropsToTopSellers',
+            'Enlight_Controller_Action_PostDispatchSecure_Widgets_Emotion'        => 'addPropsToEmotion',
             'Enlight_Controller_Action_PostDispatchSecure_Frontend_Detail'        => 'onPostDispatchFrontendDetail',
             'sArticles::sGetArticlesByCategory::after'                            => 'afterGetArticlesByCategory',
         ];
     }
 
+    public function addPropsToEmotion(\Enlight_Controller_ActionEventArgs $args)
+    {
+        $this->assignPropertiesToAction($args, 'articles');
+    }
+
     /**
      * @param \Enlight_Controller_ActionEventArgs $args
+     * @param string                              $spec
      */
-    public function onPostDispatchFrontendDetail(\Enlight_Controller_ActionEventArgs $args)
+    private function assignPropertiesToAction(\Enlight_Controller_ActionEventArgs $args, $spec)
     {
-        if (!in_array(PluginConfig::SHOW_PROPERTIES_ON_SIMILAR_ARTICLES, $this->pluginConfig->getShowPropertiesOn())) {
+        if (!in_array($args->getRequest()->getActionName(), $this->pluginConfig->getShowPropertiesOn())) {
             return;
         }
 
-        /** @var \Shopware_Controllers_Frontend_Detail $subject */
-        $view                         = $args->getSubject()->View();
-        $sArticle                     = $view->sArticle;
-        $sArticle['sSimilarArticles'] = $this->addPropertiesToArticlesArray($sArticle['sSimilarArticles']);
-
-        $view->sArticle = $sArticle;
-    }
-
-    /**
-     * @param \Enlight_Controller_ActionEventArgs $args
-     */
-    public function addPropsToTopSellers(\Enlight_Controller_ActionEventArgs $args)
-    {
-        $this->assignPropertiesToAction($args, 'sCharts');
-    }
-
-    /**
-     * @param \Enlight_Controller_ActionEventArgs $args
-     */
-    public function addPropsToBought(\Enlight_Controller_ActionEventArgs $args)
-    {
-        $this->assignPropertiesToAction($args, 'boughtArticles');
-    }
-
-    /**
-     * @param \Enlight_Hook_HookArgs $args
-     */
-    public function afterGetArticlesByCategory(\Enlight_Hook_HookArgs $args)
-    {
-        if (in_array(PluginConfig::SHOW_PROPERTIES_ON_LISTING, $this->pluginConfig->getShowPropertiesOn())) {
-            return;
-        }
-
-        $args->setReturn($this->addPropertiesToArticlesArray($args->getReturn()));
+        $view = $args->getSubject()->View();
+        $view->assign($spec, $this->addPropertiesToArticlesArray($view->getAssign($spec)));
     }
 
     /**
@@ -179,15 +154,50 @@ class FrontendProperties implements SubscriberInterface
 
     /**
      * @param \Enlight_Controller_ActionEventArgs $args
-     * @param string                              $spec
      */
-    private function assignPropertiesToAction(\Enlight_Controller_ActionEventArgs $args, $spec)
+    public function onPostDispatchFrontendDetail(\Enlight_Controller_ActionEventArgs $args)
     {
-        if (!in_array($args->getRequest()->getActionName(), $this->pluginConfig->getShowPropertiesOn())) {
+        if (!in_array(PluginConfig::SHOW_PROPERTIES_ON_SIMILAR_ARTICLES, $this->pluginConfig->getShowPropertiesOn())) {
             return;
         }
 
-        $view = $args->getSubject()->View();
-        $view->assign($spec, $this->addPropertiesToArticlesArray($view->getAssign($spec)));
+        /** @var \Shopware_Controllers_Frontend_Detail $subject */
+        $view                         = $args->getSubject()->View();
+        $sArticle                     = $view->sArticle;
+        $sArticle['sSimilarArticles'] = $this->addPropertiesToArticlesArray($sArticle['sSimilarArticles']);
+
+        $view->sArticle = $sArticle;
+    }
+
+    /**
+     * @param \Enlight_Controller_ActionEventArgs $args
+     */
+    public function addPropsToTopSellers(\Enlight_Controller_ActionEventArgs $args)
+    {
+        $this->assignPropertiesToAction($args, 'sCharts');
+    }
+
+    /**
+     * @param \Enlight_Controller_ActionEventArgs $args
+     */
+    public function addPropsToBought(\Enlight_Controller_ActionEventArgs $args)
+    {
+        $this->assignPropertiesToAction($args, 'boughtArticles');
+    }
+
+    /**
+     * @param \Enlight_Hook_HookArgs $args
+     *
+     * @return mixed
+     */
+    public function afterGetArticlesByCategory(\Enlight_Hook_HookArgs $args)
+    {
+        if (!in_array(PluginConfig::SHOW_PROPERTIES_ON_LISTING, $this->pluginConfig->getShowPropertiesOn())) {
+            return $args->getReturn();
+        }
+
+        $return              = $args->getReturn();
+        $return['sArticles'] = $this->addPropertiesToArticlesArray($return['sArticles']);
+        $args->setReturn($return);
     }
 }

--- a/Subscriber/FrontendProperties.php
+++ b/Subscriber/FrontendProperties.php
@@ -73,6 +73,9 @@ class FrontendProperties implements SubscriberInterface
         ];
     }
 
+    /**
+     * @param \Enlight_Hook_HookArgs $args
+     */
     public function afterGetArticleCharts(\Enlight_Hook_HookArgs $args)
     {
         if (!in_array(PluginConfig::SHOW_PROPERTIES_ON_TOP_SELLER, $this->pluginConfig->getShowPropertiesOn())) {

--- a/Subscriber/FrontendProperties.php
+++ b/Subscriber/FrontendProperties.php
@@ -66,30 +66,20 @@ class FrontendProperties implements SubscriberInterface
     {
         return [
             'Enlight_Controller_Action_PostDispatchSecure_Widgets_Recommendation' => 'addPropsToBought',
-            'Enlight_Controller_Action_PostDispatchSecure_Widgets_Listing'        => 'addPropsToTopSellers',
             'Enlight_Controller_Action_PostDispatchSecure_Widgets_Emotion'        => 'addPropsToEmotion',
             'Enlight_Controller_Action_PostDispatchSecure_Frontend_Detail'        => 'onPostDispatchFrontendDetail',
             'sArticles::sGetArticlesByCategory::after'                            => 'afterGetArticlesByCategory',
+            'sArticles::sGetArticleCharts::after'                                 => 'afterGetArticleCharts',
         ];
     }
 
-    public function addPropsToEmotion(\Enlight_Controller_ActionEventArgs $args)
+    public function afterGetArticleCharts(\Enlight_Hook_HookArgs $args)
     {
-        $this->assignPropertiesToAction($args, 'articles');
-    }
-
-    /**
-     * @param \Enlight_Controller_ActionEventArgs $args
-     * @param string                              $spec
-     */
-    private function assignPropertiesToAction(\Enlight_Controller_ActionEventArgs $args, $spec)
-    {
-        if (!in_array($args->getRequest()->getActionName(), $this->pluginConfig->getShowPropertiesOn())) {
+        if (!in_array(PluginConfig::SHOW_PROPERTIES_ON_TOP_SELLER, $this->pluginConfig->getShowPropertiesOn())) {
             return;
         }
 
-        $view = $args->getSubject()->View();
-        $view->assign($spec, $this->addPropertiesToArticlesArray($view->getAssign($spec)));
+        $args->setReturn($this->addPropertiesToArticlesArray((array)$args->getReturn()));
     }
 
     /**
@@ -152,6 +142,25 @@ class FrontendProperties implements SubscriberInterface
         return $products;
     }
 
+    public function addPropsToEmotion(\Enlight_Controller_ActionEventArgs $args)
+    {
+        $this->assignPropertiesToAction($args, 'articles');
+    }
+
+    /**
+     * @param \Enlight_Controller_ActionEventArgs $args
+     * @param string                              $spec
+     */
+    private function assignPropertiesToAction(\Enlight_Controller_ActionEventArgs $args, $spec)
+    {
+        if (!in_array($args->getRequest()->getActionName(), $this->pluginConfig->getShowPropertiesOn())) {
+            return;
+        }
+
+        $view = $args->getSubject()->View();
+        $view->assign($spec, $this->addPropertiesToArticlesArray($view->getAssign($spec)));
+    }
+
     /**
      * @param \Enlight_Controller_ActionEventArgs $args
      */
@@ -167,14 +176,6 @@ class FrontendProperties implements SubscriberInterface
         $sArticle['sSimilarArticles'] = $this->addPropertiesToArticlesArray($sArticle['sSimilarArticles']);
 
         $view->sArticle = $sArticle;
-    }
-
-    /**
-     * @param \Enlight_Controller_ActionEventArgs $args
-     */
-    public function addPropsToTopSellers(\Enlight_Controller_ActionEventArgs $args)
-    {
-        $this->assignPropertiesToAction($args, 'sCharts');
     }
 
     /**

--- a/config.php
+++ b/config.php
@@ -32,6 +32,10 @@ return [
                 ['similarArticles', ['de_DE' => 'Ähnliche Artikel', 'en_GB' => 'Similar articles']],
                 ['bought', ['de_DE' => 'Kunden kauften auch', 'en_GB' => 'Bought articles']],
                 ['topSeller', ['de_DE' => 'TopSeller', 'en_GB' => 'TopSellers']],
+                [
+                    'emotionArticleSlider',
+                    ['de_DE' => 'Artikel-Slider-Einkaufsweltelement', 'en_GB' => 'Article slider emotion component'],
+                ],
             ],
             'options'     => [
                 'multiSelect'    => true,


### PR DESCRIPTION
This PR fixes a fatal error in the frontend if no pages were selected for the properties subscriber.

It also improves the properties subscriber to support the article slider emotion element.