### PR TITLE
#26437 - Add properties to related articles and emotion product streams

### DIFF
--- a/Subscriber/FrontendProperties.php
+++ b/Subscriber/FrontendProperties.php
@@ -177,6 +177,7 @@ class FrontendProperties implements SubscriberInterface
         $view                         = $args->getSubject()->View();
         $sArticle                     = $view->sArticle;
         $sArticle['sSimilarArticles'] = $this->addPropertiesToArticlesArray($sArticle['sSimilarArticles']);
+        $sArticle['sRelatedArticles'] = $this->addPropertiesToArticlesArray($sArticle['sRelatedArticles']);
 
         $view->sArticle = $sArticle;
     }

--- a/config.php
+++ b/config.php
@@ -29,7 +29,7 @@ return [
             'isRequired'  => false,
             'store'       => [
                 ['listing', ['de_DE' => 'Kategorieseite', 'en_GB' => 'Category page']],
-                ['similarArticles', ['de_DE' => 'Ähnliche Artikel', 'en_GB' => 'Similar articles']],
+                ['similarArticles', ['de_DE' => 'Ähnliche Artikel / Zubehör', 'en_GB' => 'Similar / similar articles']],
                 ['bought', ['de_DE' => 'Kunden kauften auch', 'en_GB' => 'Bought articles']],
                 ['topSeller', ['de_DE' => 'TopSeller', 'en_GB' => 'TopSellers']],
                 [

--- a/config.php
+++ b/config.php
@@ -36,6 +36,10 @@ return [
                     'emotionArticleSlider',
                     ['de_DE' => 'Artikel-Slider-Einkaufsweltelement', 'en_GB' => 'Article slider emotion component'],
                 ],
+                [
+                    'productStreamArticleSlider',
+                    ['de_DE' => 'Product-Streams auf Artikelseite', 'en_GB' => 'Article page product streams'],
+                ],
             ],
             'options'     => [
                 'multiSelect'    => true,

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,10 +5,15 @@
     <label lang="de">ToolKit</label>
     <label lang="en">ToolKit</label>
 
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <link>http://www.shopinventors.de</link>
     <author>Net Inventors GmbH</author>
     <compatibility minVersion="5.2.6"/>
+
+    <changelog version="2.3.0">
+        <changes lang="de"><![CDATA[[#26437] Artikel-Eingenschaften sind jetzt auch im Zuberhör-Reiter und in Product-Streams verfügbar.]]></changes>
+        <changes lang="en"><![CDATA[[#26437] Properties are now available in the related articles tab and in product streams.]]></changes>
+    </changelog>
 
     <changelog version="2.2.1">
         <changes lang="de"><![CDATA[[#26409] Behebt einen Fehler im Frontend, wenn keine Option für sProperties gewählt wurde und verbessert die Unterstützung der TopSeller und Artikel-Slider.]]></changes>


### PR DESCRIPTION
This PR adds the properties array to articles in the "related articles" and "product streams" cross-selling tabs.