### PR TITLE
#27322 - Fix assignment of sProperties to article slider emotion template

### DIFF
--- a/Subscriber/FrontendProperties.php
+++ b/Subscriber/FrontendProperties.php
@@ -84,7 +84,7 @@ class FrontendProperties implements SubscriberInterface
     {
         $elementArray = $args->getReturn();
 
-        if (! \in_array(PluginConfig::SHOW_PROPERTIES_ON_EMOTION_ARTICLE_SLIDER,
+        if (!\in_array(PluginConfig::SHOW_PROPERTIES_ON_EMOTION_ARTICLE_SLIDER,
             $this->pluginConfig->getShowPropertiesOn(),
             true
         )) {

--- a/Subscriber/FrontendProperties.php
+++ b/Subscriber/FrontendProperties.php
@@ -12,6 +12,7 @@ namespace NetiToolKit\Subscriber;
 use Enlight\Event\SubscriberInterface;
 use NetiFoundation\Service\PluginManager\Config;
 use NetiToolKit\Struct\PluginConfig;
+use Shopware\Bundle\EmotionBundle\ComponentHandler\ArticleSliderComponentHandler;
 use Shopware\Bundle\StoreFrontBundle\Service\ContextServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Service\PropertyServiceInterface;
 use Shopware\Bundle\StoreFrontBundle\Struct\BaseProduct;
@@ -70,7 +71,31 @@ class FrontendProperties implements SubscriberInterface
             'Enlight_Controller_Action_PostDispatchSecure_Frontend_Detail'        => 'onPostDispatchFrontendDetail',
             'sArticles::sGetArticlesByCategory::after'                            => 'afterGetArticlesByCategory',
             'sArticles::sGetArticleCharts::after'                                 => 'afterGetArticleCharts',
+            'Legacy_Struct_Converter_Convert_Emotion_Element'                     => 'filterConvertedEmotionComponent',
         ];
+    }
+
+    /**
+     * @param \Enlight_Event_EventArgs $args
+     *
+     * @return mixed
+     */
+    public function filterConvertedEmotionComponent(\Enlight_Event_EventArgs $args)
+    {
+        $elementArray = $args->getReturn();
+
+        if (! \in_array(PluginConfig::SHOW_PROPERTIES_ON_EMOTION_ARTICLE_SLIDER,
+            $this->pluginConfig->getShowPropertiesOn(),
+            true
+        )) {
+            return $elementArray;
+        }
+
+        if (ArticleSliderComponentHandler::COMPONENT_NAME === $elementArray['component']['type']) {
+            $elementArray['data']['values'] = $this->addPropertiesToArticlesArray($elementArray['data']['values']);
+        }
+
+        return $elementArray;
     }
 
     /**
@@ -114,7 +139,7 @@ class FrontendProperties implements SubscriberInterface
      *
      * @return array
      */
-    private function convertPropertyStructs($propertySets)
+    private function convertPropertyStructs(array $propertySets)
     {
         // convert property set Structs to legacy Array format
         $legacyProps = [];

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,10 +5,19 @@
     <label lang="de">ToolKit</label>
     <label lang="en">ToolKit</label>
 
-    <version>2.4.0</version>
+    <version>2.4.1</version>
     <link>http://www.shopinventors.de</link>
     <author>Net Inventors GmbH</author>
     <compatibility minVersion="5.2.6"/>
+
+    <changelog version="2.4.1">
+        <changes lang="de"><![CDATA[
+[#27322] Behebt die fehlenden Artikel-Eigenschaften im Artikel-Slider-Einkaufselement unter SW5.3
+]]></changes>
+        <changes lang="en"><![CDATA[
+[#27322] Fixed the article slider emotion properties under SW5.3
+]]></changes>
+    </changelog>
 
     <changelog version="2.4.0">
         <changes lang="de"><![CDATA[[#27354] Artikel-Eigenschaften können im Frontend ausgeblendet werden.]]></changes>


### PR DESCRIPTION
Due to changes in SW5.3, a different event has to be used now to assign the properties to the article slider emotion component. 

This change is fully backward compatible. as the old event is still defined, the emotion widget controller action just isn't called, and in old versions, the presence of the new listener doesn't cause any problems either, it just won't run.